### PR TITLE
Replace API password with an API encryption key

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -12,7 +12,8 @@ wifi:
   password: !secret wifi_password
 
 api:
-  password: !secret api_password
+  encryption:
+    key: !secret api_encryption_key
 
 ota:
   password: !secret ota_password


### PR DESCRIPTION
In the yaml example configuration, replace the deprecated API password with an API encryption key.